### PR TITLE
Deno Runtimes Update

### DIFF
--- a/runtimes/build.sh
+++ b/runtimes/build.sh
@@ -15,6 +15,12 @@ docker buildx build --platform linux/amd64,linux/386 -t appwrite/runtime-for-den
 echo 'Deno 1.11...'
 docker buildx build --platform linux/amd64,linux/386 -t appwrite/runtime-for-deno:1.11 ./runtimes/deno-1.11/ --push
 
+echo 'Deno 1.12...'
+docker buildx build --platform linux/amd64,linux/386 -t appwrite/runtime-for-deno:1.12 ./runtimes/deno-1.12/ --push
+
+echo 'Deno 1.13...'
+docker buildx build --platform linux/amd64,linux/386 -t appwrite/runtime-for-deno:1.13 ./runtimes/deno-1.13/ --push
+
 echo 'Node 14.5...'
 docker buildx build --platform linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le -t appwrite/runtime-for-node:14.5 ./runtimes/node-14.5/ --push
 

--- a/runtimes/deno-1.12/Dockerfile
+++ b/runtimes/deno-1.12/Dockerfile
@@ -1,0 +1,11 @@
+FROM denoland/deno:alpine-1.12.2
+
+LABEL maintainer="team@appwrite.io"
+
+RUN apk add tar
+
+RUN mkdir /usr/local/src
+
+WORKDIR /usr/local/src/
+
+ENV DENO_DIR=/usr/local/src/.appwrite

--- a/runtimes/deno-1.13/Dockerfile
+++ b/runtimes/deno-1.13/Dockerfile
@@ -1,0 +1,11 @@
+FROM denoland/deno:alpine-1.12.2
+
+LABEL maintainer="team@appwrite.io"
+
+RUN apk add tar
+
+RUN mkdir /usr/local/src
+
+WORKDIR /usr/local/src/
+
+ENV DENO_DIR=/usr/local/src/.appwrite

--- a/src/Runtimes/Runtimes.php
+++ b/src/Runtimes/Runtimes.php
@@ -40,6 +40,8 @@ class Runtimes
         $deno->addVersion('1.8', 'hayd/deno:alpine-1.8.3', 'appwrite/runtime-for-deno:1.8', [System::X86]);
         $deno->addVersion('1.10', 'denoland/deno:alpine-1.10.3', 'appwrite/runtime-for-deno:1.10', [System::X86]);
         $deno->addVersion('1.11', 'denoland/deno:alpine-1.11.5', 'appwrite/runtime-for-deno:1.11', [System::X86]);
+        $deno->addVersion('1.12', 'denoland/deno:alpine-1.12.2', 'appwrite/runtime-for-deno:1.12', [System::X86]);
+        $deno->addVersion('1.13', 'denoland/deno:alpine-1.13.2', 'appwrite/runtime-for-deno:1.13', [System::X86]);
         $this->runtimes['deno'] = $deno;
 
         $dart = new Runtime('dart', 'Dart');


### PR DESCRIPTION
Adds two new Deno runtimes
1. Deno 1.12
2. Deno 1.13

With this should I depricate deno 1.8 and 1.10 ?