### PR TITLE
Fix: Maintain the variable define order of runtimes

### DIFF
--- a/src/Runtimes/Runtimes.php
+++ b/src/Runtimes/Runtimes.php
@@ -109,13 +109,13 @@ class Runtimes
         $supportedRuntimes = [];
 
         foreach ($this->runtimes as $runtime) {
-            $supportedRuntimes = array_merge(array_filter($runtime->list(), function (array $version, string $key) use ($supported, $filter) {
+            $supportedRuntimes = array_merge(array_reverse(array_filter($runtime->list(), function (array $version, string $key) use ($supported, $filter) {
                 $isSupported = in_array(System::getArchEnum(), $version["supports"]);
                 $isFiltered = in_array($key, $filter);
                 return $supported ? ($isSupported && ($filter ? $isFiltered : true)) : true;
-            }, ARRAY_FILTER_USE_BOTH), $supportedRuntimes);
+            }, ARRAY_FILTER_USE_BOTH)), $supportedRuntimes);
         }
 
-        return $supportedRuntimes;
+        return array_reverse($supportedRuntimes);
     }
 }


### PR DESCRIPTION
This PR adds two array reverses so the output order of getAll is the same order as they were defined within the code file.