### PR TITLE
feat: rework node runtimes versionning to follow node versions

### DIFF
--- a/src/Runtimes/Runtimes.php
+++ b/src/Runtimes/Runtimes.php
@@ -41,13 +41,29 @@ class Runtimes
         $this->version = $version;
 
         $node = new Runtime('node', 'Node.js', 'bash helpers/server.sh');
+        $node->addVersion('14', 'node:14-alpine', 'openruntimes/node:'.$this->version.'-14', [System::X86], true); # Deprecated since April 30, 2023
         $node->addVersion('14.5', 'node:14.5.0-alpine3.12', 'openruntimes/node:'.$this->version.'-14.5', [System::X86, System::ARM64, System::ARMV7, System::ARMV8], true); # Deprecated since April 30, 2023
-        $node->addVersion('16.0', 'node:16.20.2-alpine3.18', 'openruntimes/node:'.$this->version.'-16.0', [System::X86, System::ARM64, System::ARMV7, System::ARMV8], true); # Deprecated since September 11, 2023
-        $node->addVersion('18.0', 'node:18.20.4-alpine3.20', 'openruntimes/node:'.$this->version.'-18.0', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
-        $node->addVersion('19.0', 'node:19.9.0-alpine3.18', 'openruntimes/node:'.$this->version.'-19.0', [System::X86, System::ARM64]);
-        $node->addVersion('20.0', 'node:20.17.0-alpine3.20', 'openruntimes/node:'.$this->version.'-20.0', [System::X86, System::ARM64]);
-        $node->addVersion('21.0', 'node:21.7.3-alpine3.20', 'openruntimes/node:'.$this->version.'-21.0', [System::X86, System::ARM64]);
-        $node->addVersion('22', 'node:22.9.0-alpine3.20', 'openruntimes/node:'.$this->version.'-22', [System::X86, System::ARM64]);
+        $node->addVersion('16', 'node:16-alpine', 'openruntimes/node:'.$this->version.'-16', [System::X86, System::ARM64, System::ARMV7, System::ARMV8], true); # Deprecated since September 11, 2023
+        $node->addVersion('16.0', 'node:16.0.0-alpine3.13', 'openruntimes/node:'.$this->version.'-16.0', [System::X86, System::ARM64, System::ARMV7, System::ARMV8], true); # Deprecated since September 11, 2023
+        $node->addVersion('16.20', 'node:16.20.2-alpine3.18', 'openruntimes/node:'.$this->version.'-16.20', [System::X86, System::ARM64, System::ARMV7, System::ARMV8], true); # Deprecated since September 11, 2023
+        $node->addVersion('18', 'node:18-alpine', 'openruntimes/node:'.$this->version.'-18', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
+        $node->addVersion('18.0', 'node:18.0.0-alpine3.15', 'openruntimes/node:'.$this->version.'-18.0', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
+        $node->addVersion('18.20', 'node:18.20.8-alpine3.20', 'openruntimes/node:'.$this->version.'-18.20', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
+        $node->addVersion('19', 'node:19-alpine', 'openruntimes/node:'.$this->version.'-19', [System::X86, System::ARM64]);
+        $node->addVersion('19.0', 'node:19.0.0-alpine3.16', 'openruntimes/node:'.$this->version.'-19.0', [System::X86, System::ARM64]);
+        $node->addVersion('19.9', 'node:19.9.0-alpine3.17', 'openruntimes/node:'.$this->version.'-19.9', [System::X86, System::ARM64]);
+        $node->addVersion('20', 'node:20-alpine', 'openruntimes/node:'.$this->version.'-20', [System::X86, System::ARM64]);
+        $node->addVersion('20.0', 'node:20.0.0-alpine3.17', 'openruntimes/node:'.$this->version.'-20.0', [System::X86, System::ARM64]);
+        $node->addVersion('20.17', 'node:20.17.0-alpine3.20', 'openruntimes/node:'.$this->version.'-20.17', [System::X86, System::ARM64]);
+        $node->addVersion('21', 'node:21-alpine', 'openruntimes/node:'.$this->version.'-21', [System::X86, System::ARM64]);
+        $node->addVersion('21.0', 'node:21.0.0-alpine3.18', 'openruntimes/node:'.$this->version.'-21.0', [System::X86, System::ARM64]);
+        $node->addVersion('21.7', 'node:21.7.3-alpine3.20', 'openruntimes/node:'.$this->version.'-21.7', [System::X86, System::ARM64]);
+        $node->addVersion('22', 'node:22-alpine', 'openruntimes/node:'.$this->version.'-22', [System::X86, System::ARM64]);
+        $node->addVersion('22.9', 'node:22.9.0-alpine3.20', 'openruntimes/node:'.$this->version.'-22.9', [System::X86, System::ARM64]);
+        $node->addVersion('22.17', 'node:22.17.0-alpine3.20', 'openruntimes/node:'.$this->version.'-22.17', [System::X86, System::ARM64]);
+        $node->addVersion('24', 'node:24-alpine', 'openruntimes/node:'.$this->version.'-24', [System::X86, System::ARM64]);
+        $node->addVersion('24.0', 'node:24.0.0-alpine3.19', 'openruntimes/node:'.$this->version.'-24.0', [System::X86, System::ARM64]);
+        $node->addVersion('24.4', 'node:24.4.0-alpine3.20', 'openruntimes/node:'.$this->version.'-24.4', [System::X86, System::ARM64]);
         $this->runtimes['node'] = $node;
 
         $php = new Runtime('php', 'PHP', 'bash helpers/server.sh');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This is a work of the node versionning as only node runtime 14.5 followed the the node version.
All the others node runtimes versions are `vXX.0` and the node version is NOT `vXX.0` (for example runtime `v20.0` is node `v20.17` and not `v20.0`)

To resolve this i followed this pattern:
- `node-<major>` : use the `node:<major>-alpine` image (may change to keep it as the latest major)
- `node-<major>.0` : use the `node:<major>.0.0-alpine<alpVersion>` (always include a first minor at 0)
- `node-<major>.<minor>`: use the `node:<major>.<minor>.<patch>-alpine<alpVersion>` (can be created when new node images are created, should never change as thoses use the whole version with patches)

## Test Plan

The runtimes tests where done through the `open-runtimes/open-runtimes` project.
I checked with files diff and multiple AIs to check if i didn't miss any versions in this project.

## Related PRs and Issues

OpenRuntimes PR : https://github.com/open-runtimes/open-runtimes/pull/413
Issues : https://github.com/open-runtimes/open-runtimes/issues/412 and #89 as it will add the latest node 20/22/24

## Additionnal Infos

Like i said in the openruntimes PR, i modeified the existing node runtimes to match the new pattern, tho it might break exiting project as the node version is lower than before (since before runtime `v20.0` was node `v20.17` now with the new pattern it will be node `v20.0` for that runtime), if you prefer i can omit the changes on the existing runtimes to avoid breaking existing functions/sites.
And if i need to change it, please tell me if you would like me to rewrite the commits or just add a new commit that bring the old runtimes back.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes