### PR TITLE
feat: add python3.13 and python3.14 support

### DIFF
--- a/src/Runtimes/Runtimes.php
+++ b/src/Runtimes/Runtimes.php
@@ -70,11 +70,15 @@ class Runtimes
         $python->addVersion('3.10', 'python:3.10.15-alpine3.20', 'openruntimes/python:'.$this->version.'-3.10', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
         $python->addVersion('3.11', 'python:3.11.10-alpine3.20', 'openruntimes/python:'.$this->version.'-3.11', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
         $python->addVersion('3.12', 'python:3.12.6-alpine3.20', 'openruntimes/python:'.$this->version.'-3.12', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
+        $python->addVersion('3.13', 'python:3.13.0-alpine3.20', 'openruntimes/python:'.$this->version.'-3.13', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
+        $python->addVersion('3.14', 'python:3.14-alpine3.22', 'openruntimes/python:'.$this->version.'-3.14', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
         $this->runtimes['python'] = $python;
 
         $pythonML = new Runtime('python-ml', 'Python (ML)', 'bash helpers/server.sh');
         $pythonML->addVersion('3.11', 'python:3.11.10-bookworm', 'openruntimes/python-ml:'.$this->version.'-3.11', [System::X86, System::ARM64]);
         $pythonML->addVersion('3.12', 'python:3.12.6-bookworm', 'openruntimes/python-ml:'.$this->version.'-3.12', [System::X86, System::ARM64]);
+        $pythonML->addVersion('3.13', 'python:3.13.0-bookworm', 'openruntimes/python-ml:'.$this->version.'-3.13', [System::X86, System::ARM64]);
+        $pythonML->addVersion('3.14', 'python:3.14-bookworm', 'openruntimes/python-ml:'.$this->version.'-3.14', [System::X86, System::ARM64]);
         $this->runtimes['python-ml'] = $pythonML;
 
         $deno = new Runtime('deno', 'Deno', 'bash helpers/server.sh');


### PR DESCRIPTION
Related to: https://github.com/appwrite/runtimes/issues/92

**Summary**
Adds support for Python 3.13 and 3.14 for both standard and ML runtimes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python versions 3.13 and 3.14 to available runtime environments, enabling developers to use the latest Python releases.
  
  
  **Screenshot**
- All the Docker images are present and valid
<img width="1122" height="844" alt="Screenshot 2025-11-04 at 9 50 16 AM" src="https://github.com/user-attachments/assets/0d489ade-dc57-4bcf-b996-ad937b46197f" />


<!-- end of auto-generated comment: release notes by coderabbit.ai -->