### PR TITLE
Feat: Flutter 3.38 and Dart 3.10

### DIFF
--- a/src/Runtimes/Runtimes.php
+++ b/src/Runtimes/Runtimes.php
@@ -98,6 +98,7 @@ class Runtimes
         $dart->addVersion('3.5', 'dart:3.5.2', 'openruntimes/dart:'.$this->version.'-3.5', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
         $dart->addVersion('3.8', 'dart:3.8', 'openruntimes/dart:'.$this->version.'-3.8', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
         $dart->addVersion('3.9', 'dart:3.9.3', 'openruntimes/dart:'.$this->version.'-3.9', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
+        $dart->addVersion('3.10', 'dart:3.10.0', 'openruntimes/dart:'.$this->version.'-3.10', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
         $this->runtimes['dart'] = $dart;
 
         $dotnet = new Runtime('dotnet', '.NET', 'bash helpers/server.sh');
@@ -152,7 +153,8 @@ class Runtimes
         $flutter->addVersion('3.27', 'ghcr.io/cirruslabs/flutter:3.27.3', 'openruntimes/flutter:'.$this->version.'-3.27', [System::X86, System::ARM64]);
         $flutter->addVersion('3.29', 'ghcr.io/cirruslabs/flutter:3.29.1', 'openruntimes/flutter:'.$this->version.'-3.29', [System::X86, System::ARM64]);
         $flutter->addVersion('3.32', 'ghcr.io/cirruslabs/flutter:3.32.0', 'openruntimes/flutter:'.$this->version.'-3.32', [System::X86, System::ARM64]);
-        $flutter->addVersion('3.35', 'ghcr.io/cirruslabs/flutter:3.35.4', 'openruntimes/flutter:'.$this->version.'-3.35', [System::X86, System::ARM64]);
+        $flutter->addVersion('3.35', 'ghcr.io/cirruslabs/flutter:3.35.7', 'openruntimes/flutter:'.$this->version.'-3.35', [System::X86, System::ARM64]);
+        $flutter->addVersion('3.38', 'ghcr.io/cirruslabs/flutter:3.38.0', 'openruntimes/flutter:'.$this->version.'-3.38', [System::X86, System::ARM64]);
         $this->runtimes['flutter'] = $flutter;
     }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Enable Flutter 3.38 and Dart 3.10
- Update base image version for Flutter 3.35

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

- https://github.com/open-runtimes/open-runtimes/pull/446

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Dart runtime version 3.10 across all architectures
  * Extended Flutter runtime support with versions 3.35 and 3.38, enabling access to the latest framework releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->