### PR TITLE
Add Dart 3.12 and Flutter 3.44 runtimes

### DIFF
--- a/src/Runtimes/Runtimes.php
+++ b/src/Runtimes/Runtimes.php
@@ -112,6 +112,7 @@ class Runtimes
         $dart->addVersion('3.9', 'dart:3.9.3', 'openruntimes/dart:'.$this->version.'-3.9', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
         $dart->addVersion('3.10', 'dart:3.10.0', 'openruntimes/dart:'.$this->version.'-3.10', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
         $dart->addVersion('3.11', 'dart:3.11.0', 'openruntimes/dart:'.$this->version.'-3.11', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
+        $dart->addVersion('3.12', 'dart:3.12.0', 'openruntimes/dart:'.$this->version.'-3.12', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
         $this->runtimes['dart'] = $dart;
 
         $dotnet = new Runtime('dotnet', '.NET', 'bash helpers/server.sh');
@@ -182,6 +183,7 @@ class Runtimes
         $flutter->addVersion('3.35', 'ghcr.io/cirruslabs/flutter:3.35.7', 'openruntimes/flutter:'.$this->version.'-3.35', [System::X86, System::ARM64]);
         $flutter->addVersion('3.38', 'ghcr.io/cirruslabs/flutter:3.38.0', 'openruntimes/flutter:'.$this->version.'-3.38', [System::X86, System::ARM64]);
         $flutter->addVersion('3.41', 'ghcr.io/cirruslabs/flutter:3.41.0', 'openruntimes/flutter:'.$this->version.'-3.41', [System::X86, System::ARM64]);
+        $flutter->addVersion('3.44', 'ghcr.io/adrianjagielak/flutter:3.44.0', 'openruntimes/flutter:'.$this->version.'-3.44', [System::X86, System::ARM64]);
         $this->runtimes['flutter'] = $flutter;
     }
 


### PR DESCRIPTION
## Summary
Adds two new runtime versions to the available runtimes configuration:

- **Dart 3.12.0** — image `dart:3.12.0`, architectures X86, ARM64, ARMV7, ARMV8
- **Flutter 3.44.0** — image `ghcr.io/adrianjagielak/flutter:3.44.0`, architectures X86, ARM64

## Notes
The new Flutter entry pins to `ghcr.io/adrianjagielak/flutter`, the community continuation of `cirruslabs/docker-images-flutter` which was deprecated in May 2026 when Cirrus Labs wound down its image-hosting after an acquisition (their last published image is `3.41.9`). The upstream README positions adrianjagielak as drop-in compatible — same tag scheme, same architectures.

The existing Flutter entries (3.24 — 3.41) continue to reference the cirruslabs registry and are intentionally left untouched in this PR; a follow-up can migrate them in bulk if desired.

Pairs with the merged open-runtimes images:
- open-runtimes/open-runtimes#495 (Dart 3.12)
- open-runtimes/open-runtimes#496 (Flutter 3.44)