### PR TITLE
docs: fix code of conduct link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -26,7 +26,7 @@ body:
   - type: checkboxes
     id: read-code-of-conduct
     attributes:
-      description: "This is our [Code of Conduct](https://github.com/appwrite/appwrite/blob/master/CODE_OF_CONDUCT.md)."
+      description: "This is our [Code of Conduct](https://github.com/appwrite/runtimes/blob/main/CODE_OF_CONDUCT.md)."
       label: "🏢 Have you read the Code of Conduct?"
       options:
         - label: "I read the Code of Conduct"


### PR DESCRIPTION
Summary
- Updates the documentation issue template to link to this repository's Code of Conduct.
- Replaces the old appwrite/appwrite URL, which redirects to a missing page.
- Keeps the change limited to the issue template URL.

Validation
- `curl.exe -L -I https://github.com/appwrite/appwrite/blob/master/CODE_OF_CONDUCT.md` -> 404 after redirect to `https://github.com/appwrite/appwrite/blob/main/CODE_OF_CONDUCT.md`.
- `curl.exe -L -I https://github.com/appwrite/runtimes/blob/main/CODE_OF_CONDUCT.md` -> 200.
- PowerShell content check confirmed the new URL is present and the old URL is absent.
- `git diff --check` passed.
- `composer validate --strict` was not run because Composer is not available in the local PATH; this change only updates a GitHub issue-template link.

Notes
- Closes #90.
- No runtime code or compatibility impact.
- No follow-up work expected.